### PR TITLE
Background tweaks

### DIFF
--- a/SiteStyle/global.css
+++ b/SiteStyle/global.css
@@ -3,12 +3,12 @@
 	
 	
 		body {
-		
+		background-color: #432C36;
 		background-image: url("../Images/MLogan_WebsiteBackground.jpg");
 		background-repeat: no-repeat;
 		background-attachment: fixed;
 		background-position: center; 
-		background-size: 1366px 768px;
+		background-size: cover;
 		font-family: "Century Gothic", CenturyGothic, AppleGothic, sans-serif;
 		font-size: 24px;
 		font-style: normal;


### PR DESCRIPTION
Hey, I checked back and saw the images are uploaded - awesome! I also think I understand what you were saying about the background now, I think this will make it do what you want.

The main change is setting the `background-size` to `cover` - this makes the browser stretch the image to cover the entire background, while preserving it's aspect ratio (so it may get cropped a bit, but it's all handled that automatically)

I also picked a color from one of the clouds to use as a default background color while the image is loading (and for the overscroll background color.)